### PR TITLE
fix build error

### DIFF
--- a/cos_c_sdk/cos_utility.h
+++ b/cos_c_sdk/cos_utility.h
@@ -31,6 +31,7 @@ int is_should_retry(const cos_status_t *s, const char *str);
 int is_default_domain(const char *str);
 int is_should_retry_endpoint(const cos_status_t *s, const char *str);
 int check_status_with_resp_body(cos_list_t *body, int64_t body_len, const char *target);
+int object_key_simplify_check(const char * object_path);
 int is_default_endpoint(const char *str);
 int change_host_suffix(char **endpoint);
 void change_endpoint_suffix(cos_string_t *endpoint);

--- a/cos_c_sdk_test/cos_demo.c
+++ b/cos_c_sdk_test/cos_demo.c
@@ -1089,7 +1089,7 @@ void test_cos_download_part_to_file()
     cos_str_set(&object, TEST_MULTIPART_OBJECT4);
     cos_str_set(&filepath, TEST_DOWNLOAD_NAME4);
 
-    s = cos_download_part_to_file(options, &bucket, &object, &filepath, &resp_headers);
+    s = cos_download_part_to_file(options, &bucket, &object, (cos_upload_file_t*) &filepath, &resp_headers);
     log_status(s);
 
     cos_pool_destroy(p);


### PR DESCRIPTION
Fix the follow build errors:

```
cos_c_sdk/cos_multipart.c:892:10: 错误：implicit declaration of function ‘object_key_simplify_check’; did you mean ‘set_object_key
_simplify_check’? [-Wimplicit-function-declaration]
  892 |     if (!object_key_simplify_check(object->data)){
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
      |          set_object_key_simplify_check
```

```
cos_c_sdk_test/cos_demo.c:1092:62: 错误：传递‘cos_download_part_to_file’的第 4 个参数时在不兼容的指针类型间转换 [-Wincompatible-pointer-types]
 1092 |     s = cos_download_part_to_file(options, &bucket, &object, &filepath, &resp_headers);
      |                                                              ^~~~~~~~~
      |                                                              |
      |                                                              cos_string_t *
```